### PR TITLE
Issue4 create drupal user

### DIFF
--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -30,7 +30,7 @@ class MB_Toolbox
    * Send request to Drupal /api/v1/users end point to create a new user
    * account.
    *
-   * @param array $user
+   * @param object $user
    *   Details about the user to create Drupal account for.
    *
    *   - $user->email (required)


### PR DESCRIPTION
Fixes #4 
- Adds `createDrupalUser($user)` as public function of `MB_Toolbox` class. **Not** static has the method contains references to $this for StatHat logging.
