### PR TITLE
Adds isDSAffiliate()

### DIFF
--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -30,7 +30,7 @@ class MB_Toolbox
    * Test if country code has a  DoSomething affiliate.
    *
    * Follow country code convention defined in:
-   * http://dev.maxmind.com/geoip/legacy/codes/iso3166/
+   * http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
    *
    * @param string $targetCountyCode
    *   Details about the user to create Drupal account for.


### PR DESCRIPTION
Fixes #4 
- Adds `createDrupalUser($user)` as public function of `MB_Toolbox` class. **Not** stastic has the method contains references to $this for StatHat logging.
