### PR TITLE
Fixes support for authenticated token and cookie in POSTs

### DIFF
--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -222,7 +222,7 @@ class MB_Toolbox
       $this->authenticate();
     }
 
-    $results = $this->curlPOST($curlUrl, $post, 'curlPOSTauth');
+    $results = $this->curlPOST($curlUrl, $post, TRUE);
 
     return $results;
   }
@@ -234,14 +234,13 @@ class MB_Toolbox
    *  The URL to POST to. Include domain and path.
    * @param array $post
    *  The values to POST.
-   * @param string $origin
-   *  Optional method name calling curlPOST. Use curlPOSTauth() to trigger
-   *  sending token and cookie auth values in header.
+   * @param boolean $isAuth
+   *  Optional flag to denote if the method is being called from curlPOSTauth().
    *
    * @return object $result
    *   The results returned from the cURL call.
    */
-  public function curlPOST($curlUrl, $post, $origin = '') {
+  public function curlPOST($curlUrl, $post, $isAuth = FALSE) {
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $curlUrl);
@@ -253,7 +252,7 @@ class MB_Toolbox
 
     // Only add token and cookie values to header when values are available and
     // the curlPOSTauth() method is making the POST request.
-    if (isset($this->auth->token) && $origin == 'curlPOSTauth') {
+    if (isset($this->auth->token) && $isAuth) {
       curl_setopt($ch, CURLOPT_HTTPHEADER,
         array(
           'Content-type: application/json',

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -283,10 +283,16 @@ class MB_Toolbox
    */
   private function authenticate() {
 
-    $post = array(
-      'username' => $this->settings['ds_drupal_api_username'],
-      'password' => $this->settings['ds_drupal_api_password'],
-    );
+    if (isset($this->settings['ds_drupal_api_username']) && $this->settings['ds_drupal_api_password']) {
+      $post = array(
+        'username' => $this->settings['ds_drupal_api_username'],
+        'password' => $this->settings['ds_drupal_api_password'],
+      );
+    }
+    else {
+      trigger_error("MB_Toolbox->authenticate() : username and/or password not defined.", E_USER_ERROR);
+      exit(0);
+    }
 
     // @todo: Abstract into it's own function
     $curlUrl = $this->settings['ds_drupal_api_host'];

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -222,7 +222,7 @@ class MB_Toolbox
       $this->authenticate();
     }
 
-    $results = $this->curlPOST($curlUrl, $post);
+    $results = $this->curlPOST($curlUrl, $post, 'curlPOSTauth');
 
     return $results;
   }
@@ -232,14 +232,16 @@ class MB_Toolbox
    *
    * @param string $curlUrl
    *  The URL to POST to. Include domain and path.
-   *
    * @param array $post
    *  The values to POST.
+   * @param string $origin
+   *  Optional method name calling curlPOST. Use curlPOSTauth() to trigger
+   *  sending token and cookie auth values in header.
    *
    * @return object $result
    *   The results returned from the cURL call.
    */
-  public function curlPOST($curlUrl, $post) {
+  public function curlPOST($curlUrl, $post, $origin = '') {
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $curlUrl);
@@ -251,7 +253,7 @@ class MB_Toolbox
 
     // Only add token and cookie values to header when values are available and
     // the curlPOSTauth() method is making the POST request.
-    if (isset($this->auth->token) && debug_backtrace(2)[1]['function'] == 'curlPOSTauth') {
+    if (isset($this->auth->token) && $origin == 'curlPOSTauth') {
       curl_setopt($ch, CURLOPT_HTTPHEADER,
         array(
           'Content-type: application/json',

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -285,7 +285,7 @@ class MB_Toolbox
    */
   private function authenticate() {
 
-    if (isset($this->settings['ds_drupal_api_username']) && $this->settings['ds_drupal_api_password']) {
+    if (!empty($this->settings['ds_drupal_api_username']) && !empty($this->settings['ds_drupal_api_password'])) {
       $post = array(
         'username' => $this->settings['ds_drupal_api_username'],
         'password' => $this->settings['ds_drupal_api_password'],

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -26,7 +26,7 @@ class MB_Toolbox
   private $statHat;
 
   /**
-   * Authenication details from Drupal site
+   * Authentication details from Drupal site
    *
    * @var object
    */
@@ -58,7 +58,7 @@ class MB_Toolbox
    *   Details about the user to create Drupal account for.
    *
    * @return boolean/array $foundAffiliate
-   *   Test if supplied country code is a DoSomething affiliate country the url
+   *   Test if supplied country code is a DoSomething affiliate country the URL
    *   to the affiliate site is returned vs boolean false if match is not found.
    */
   public function isDSAffiliate($targetCountyCode) {
@@ -205,7 +205,7 @@ class MB_Toolbox
   }
 
   /**
-   * cURL POSTs with authenication
+   * cURL POSTs with authentication
    *
    * @param string $curlUrl
    *  The URL to POST to. Include domain and path.
@@ -213,7 +213,7 @@ class MB_Toolbox
    *  The values to POST.
    *
    * @return object $result
-   *   The results retruned from the cURL call.
+   *   The results returned from the cURL call.
    */
   public function curlPOSTauth($curlUrl, $post) {
 
@@ -237,7 +237,7 @@ class MB_Toolbox
    *  The values to POST.
    *
    * @return object $result
-   *   The results retruned from the cURL call.
+   *   The results returned from the cURL call.
    */
   public function curlPOST($curlUrl, $post) {
 
@@ -249,7 +249,9 @@ class MB_Toolbox
     curl_setopt($ch,CURLOPT_CONNECTTIMEOUT, 3);
     curl_setopt($ch,CURLOPT_TIMEOUT, 20);
 
-    if (isset($this->auth->token)) {
+    // Only add token and cookie values to header when values are available and
+    // the curlPOSTauth() method is making the POST request.
+    if (isset($this->auth->token) && debug_backtrace(2)[1]['function'] == 'curlPOSTauth') {
       curl_setopt($ch, CURLOPT_HTTPHEADER,
         array(
           'Content-type: application/json',


### PR DESCRIPTION
The "mb-toolbox" library is used by various scripts within the Message Broker system. The MB_Toolbox class provides common methods including support for cURL calls to http://dosomething.org.

This pull request adds support for token and cookie values in cURL POST calls as required by some endpoints defined in the DoSomething API.

The "token" and "session" values are defined by calling `/auth/login`.
```
    if (isset($this->auth->token)) {
      curl_setopt($ch, CURLOPT_HTTPHEADER,
        array(
          'Content-type: application/json',
          'Accept: application/json',
          'X-CSRF-Token: ' . $this->auth->token,
          'Cookie: ' . $this->auth->session_name . '=' . $this->auth->sessid
        )
      );
    }
    else {
      curl_setopt($ch, CURLOPT_HTTPHEADER,
        array(
          'Content-type: application/json',
          'Accept: application/json'
        )
      );
    }
```
An example use case is the need for authentication values when calling POST `https://www.dosomething.org/api/v1/campaigns/[nid]/signup`. Details: 
https://github.com/DoSomething/dosomething/wiki/API#campaign-signup

**Related**:
https://github.com/DoSomething/mbc-user-import/pull/26