### PR TITLE
Issue24 subscription link

### DIFF
--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -159,7 +159,7 @@ class MB_Toolbox
     $ch = curl_init();
     $drupalAPIUrl = $this->settings['ds_drupal_api_host'];
     $port = $this->settings['ds_drupal_api_port'];
-    if ($port != 0) {
+    if ($port > 0) {
       $drupalAPIUrl .= ":{$port}";
     }
     $drupalAPIUrl .= self::DRUPAL_API . '/users';
@@ -193,7 +193,7 @@ class MB_Toolbox
 
     $curlUrl = $this->settings['ds_drupal_api_host'];
     $port = $this->settings['ds_drupal_api_port'];
-    if ($port != 0 && is_numeric($port)) {
+    if ($port > 0 && is_numeric($port)) {
       $curlUrl .= ':' . (int) $port;
     }
     $curlUrl .= self::DRUPAL_API . '/users/get_member_count';
@@ -372,7 +372,7 @@ class MB_Toolbox
     // @todo: Abstract into it's own function
     $curlUrl = $this->settings['ds_drupal_api_host'];
     $port = $this->settings['ds_drupal_api_port'];
-    if ($port != 0 && is_numeric($port)) {
+    if ($port > 0 && is_numeric($port)) {
       $curlUrl .= ':' . (int) $port;
     }
 
@@ -403,7 +403,7 @@ class MB_Toolbox
 
     $curlUrl = $this->settings['ds_drupal_api_host'];
     $port = $this->settings['ds_drupal_api_port'];
-    if ($port != 0 && is_numeric($port)) {
+    if ($port > 0 && is_numeric($port)) {
       $curlUrl .= ':' . (int) $port;
     }
     $curlUrl .= self::DRUPAL_API . '/users?parameters[email]=' . $targetEmail;

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -294,7 +294,7 @@ class MB_Toolbox
    * @param array $get
    *  The values to GET.
    * @param boolean $isAuth
-   *  A flag to keep track of the current authencation state.
+   *  A flag to keep track of the current authentication state.
    *
    * @return object $result
    *   The results returned from the cURL call.
@@ -317,7 +317,7 @@ class MB_Toolbox
    * @param string $curlUrl
    *  The URL to GET from. Include domain and path.
    * @param boolean $isAuth
-   *  A flag to keep track of the current authencation state.
+   *  A flag to keep track of the current authentication state.
    *
    * @return object $result
    *   The results returned from the cURL call.
@@ -384,6 +384,44 @@ class MB_Toolbox
     $auth = $this->curlPOST($curlUrl, $post);
 
     $this->auth = $auth;
+  }
+
+   /**
+   * Generate user specific link URL to user subscription setting
+   * (http://subscriptions.dosomething.org) web page. The page is an interface
+   * to allow users to subscribe/unsubscribe to different types of email
+   * messaging.
+   *
+   * @param string $targetEmail
+   *   The email address to generate the subscription URL for.
+   *
+   * @return string $subscription_link
+   *   The URL to the user subscription settings web page. The link includes a
+   *   key md5 hash value to limit page access to authorized users who have
+   *   received an email from the lists the subscription page administers.
+   */
+  public function subscriptionsLinkGenerator($targetEmail) {
+
+    $curlUrl = $this->settings['ds_drupal_api_host'];
+    $port = $this->settings['ds_drupal_api_port'];
+    if ($port != 0 && is_numeric($port)) {
+      $curlUrl .= ':' . (int) $port;
+    }
+    $curlUrl .= self::DRUPAL_API . '/users?parameters[email]=' . $targetEmail;
+
+    $result = $this->curlGETauth($curlUrl);
+    if (isset($result->uid)) {
+      $drupalUID = $result->uid;
+
+      $keyData = $targetEmail . ', ' . $drupalUID . ', ' . date('Y-m-d');
+      $subscription_link = 'http://subscriptions.dosomething.org?email=' . $targetEmail . '&key=' . md5($keyData);
+    }
+    else {
+      echo 'Error making GET request to ' . $curlUrl, PHP_EOL;
+      $subscription_link = FALSE;
+    }
+
+    return $subscription_link;
   }
 
 }

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -399,6 +399,8 @@ class MB_Toolbox
    */
   public function subscriptionsLinkGenerator($targetEmail) {
 
+    $this->statHat->clearAddedStatNames();
+
     $curlUrl = $this->settings['ds_drupal_api_host'];
     $port = $this->settings['ds_drupal_api_port'];
     if ($port != 0 && is_numeric($port)) {
@@ -412,11 +414,16 @@ class MB_Toolbox
 
       $keyData = $targetEmail . ', ' . $drupalUID . ', ' . date('Y-m-d');
       $subscription_link = self::SUBSCRIPTIONS_URL . '?email=' . $targetEmail . '&key=' . md5($keyData);
+
+      $this->statHat->addStatName('subscriptionsLinkGenerator Success');
     }
     else {
       echo 'Error making GET request to ' . $curlUrl, PHP_EOL;
       $subscription_link = FALSE;
+
+      $this->statHat->addStatName('subscriptionsLinkGenerator ERROR');
     }
+    $this->statHat->reportCount(1);
 
     return $subscription_link;
   }

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -287,67 +287,24 @@ class MB_Toolbox
   }
 
   /**
-   * cURL POSTs with authentication
-   *
-   * @param string $curlUrl
-   *  The URL to POST to. Include domain and path.
-   * @param array $get
-   *  The values to GET.
-   * @param boolean $isAuth
-   *  A flag to keep track of the current authentication state.
-   *
-   * @return object $result
-   *   The results returned from the cURL call.
-   */
-  public function curlGETauth($curlUrl, $get) {
-
-    // Remove authentication until POST to /api/v1/auth/login is resolved
-    if (!isset($this->auth)) {
-      $this->authenticate();
-    }
-
-    $results = $this->curlGET($curlUrl, TRUE);
-
-    return $results;
-  }
-
-  /**
    * cURL GETs
    *
    * @param string $curlUrl
    *  The URL to GET from. Include domain and path.
-   * @param boolean $isAuth
-   *  A flag to keep track of the current authentication state.
    *
    * @return object $result
    *   The results returned from the cURL call.
    */
-  public function curlGET($curlUrl, $isAuth = FALSE) {
+  public function curlGET($curlUrl) {
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $curlUrl);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-
-   // Only add token and cookie values to header when values are available and
-    // the curlPOSTauth() method is making the POST request.
-    if (isset($this->auth->token) && $isAuth) {
-      curl_setopt($ch, CURLOPT_HTTPHEADER,
-        array(
-          'Content-type: application/json',
-          'Accept: application/json',
-          'X-CSRF-Token: ' . $this->auth->token,
-          'Cookie: ' . $this->auth->session_name . '=' . $this->auth->sessid
-        )
-      );
-    }
-    else {
-      curl_setopt($ch, CURLOPT_HTTPHEADER,
+    curl_setopt($ch, CURLOPT_HTTPHEADER,
         array(
           'Content-type: application/json',
           'Accept: application/json'
-        )
-      );
-    }
+        ));
 
     $jsonResult = curl_exec($ch);
     $results = json_decode($jsonResult);

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -300,11 +300,10 @@ class MB_Toolbox
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $curlUrl);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_HTTPHEADER,
-        array(
-          'Content-type: application/json',
-          'Accept: application/json'
-        ));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+      'Content-type: application/json',
+      'Accept: application/json'
+    ));
 
     $jsonResult = curl_exec($ch);
     $results = json_decode($jsonResult);

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -10,6 +10,7 @@ class MB_Toolbox
 {
 
   const DRUPAL_API = '/api/v1';
+  const SUBSCRIPTIONS_URL = 'http://subscriptions.dosomething.org';
 
   /**
    * Service settings
@@ -370,7 +371,7 @@ class MB_Toolbox
       $drupalUID = $result->uid;
 
       $keyData = $targetEmail . ', ' . $drupalUID . ', ' . date('Y-m-d');
-      $subscription_link = 'http://subscriptions.dosomething.org?email=' . $targetEmail . '&key=' . md5($keyData);
+      $subscription_link = self::SUBSCRIPTIONS_URL . '?email=' . $targetEmail . '&key=' . md5($keyData);
     }
     else {
       echo 'Error making GET request to ' . $curlUrl, PHP_EOL;


### PR DESCRIPTION
Fixes #24 

Public method to support generation of a link to the user subscription web page. The page will allow the user to adjust their email subscription preferences to specific mailing lists. Example link:
```
http://subscriptions.dosomething.org?email=test@test.com&key=1234567890QWERTYUIOPlkjhgfdsa
```
**Related**:
https://github.com/DoSomething/mb-toolbox/pull/26