### PR TITLE
Default text

### DIFF
--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -240,7 +240,7 @@ class MB_Toolbox
       $memberCountFormatted = $result->readable;
     }
     else {
-      $memberCountFormatted = NULL;
+      $memberCountFormatted = 'millions of';
     }
     return $memberCountFormatted;
   }


### PR DESCRIPTION
Fixes #41 

Based on testing, it appears the value for \*|MEMBER_COUNT|\* is not set with a cURL call to the Drupal app. This PR provides a default text value to prevent the merge_tag from be displayed in the email messages.