### PR TITLE
Issue52 singleton pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "dosomething/mb-toolbox",
   "type": "library",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A library of functionality shared between the components that make up the Message Broker system: https://github.com/DoSomething/message-broker. Some of the functionality is DoSomething.org specific.",
   "keywords": ["rabbitmq", "message broker php library"],
   "homepage": "https://github.com/DoSomething/mb-toolbox",

--- a/src/MB_Configuration.php
+++ b/src/MB_Configuration.php
@@ -32,8 +32,22 @@ class MB_Configuration
 
   /**
    * Constructor - private to enforce singleton pattern. Only once instance of class allowed.
+   *
+   * Protected constructor to prevent creating a new instance of the *Singleton* via the
+   * `new` operator from outside of the class.
+   *
+   * See: http://www.phptherightway.com/pages/Design-Patterns.html
    */
   private function __construct() {}
+
+  /**
+   * Private clone method to prevent cloning of the instance of the
+   * *Singleton* instance.
+   *
+   * The magic method __clone() is declared as private to prevent cloning of an instance
+   * of the class via the clone operator.
+   */
+  private function __clone() {}
 
   /**
    * Static method to limit instantiation of class to only one object.

--- a/src/MB_Toolbox_BaseConsumer.php
+++ b/src/MB_Toolbox_BaseConsumer.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * A template for all producer classes within the Message Broker system.
+ */
 
 namespace DoSomething\MB_Toolbox;
 

--- a/src/MB_Toolbox_BaseConsumer.php
+++ b/src/MB_Toolbox_BaseConsumer.php
@@ -84,12 +84,12 @@ abstract class MB_Toolbox_BaseConsumer
    * @param array $settings
    *   Settings from internal and external services used by the application.
    */
-  public function __construct($messageBroker, StatHat $statHat, MB_Toolbox $toolbox, $settings) {
+  public function __construct() {
 
-    $this->messageBroker = $messageBroker;
-    $this->statHat = $statHat;
-    $this->toolbox = $toolbox;
-    $this->settings = $settings;
+    $this->mbConfig = MB_Configuration::getInstance();
+    $this->messageBroker = $this->mbConfig->getProperty('messageBroker');
+    $this->statHat = $this->mbConfig->getProperty('statHat');
+    $this->toolbox = $this->mbConfig->getProperty('mbToolbox');
   }
 
   /**


### PR DESCRIPTION
Fixes #52 

Using the Singleton pattern, use MB_Configuration to manage application configuration settings. Setting can include text / number values as well as objects of services for the application to access.

**Example**:
```
$mbConfig = MB_Configuration::getInstance();
$mb = $mbConfig->getProperty('messageBroker');
$mb->consumeMessage(array(new MBC_RegistrationMobile_Consumer(), 'consumeRegistrationMobileQueue'));
```

All settings are available application wide in any class without the need to pass the `MB_Configuration` object as a class parameter.
