### PR TITLE
Issue61 create nothstar user

### DIFF
--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -13,7 +13,7 @@ class MB_Toolbox
 {
 
   const DRUPAL_API = '/api/v1';
-  const NORTHSTAR = '/v1';
+  const NORTHSTAR_API_VERSION = 'v1';
   const DEFAULT_USERNAME = 'Doer';
 
   /**
@@ -212,12 +212,12 @@ class MB_Toolbox
 
     // Required - at least one of email or mobile must be set.
      $requiredSet = false;
-    if (isset($user->email)) {
+    if (!empty($user->email)) {
       $post['email'] = $user->email;
       $requiredSet = true;
     }
 
-    if (isset($user->mobile)) {
+    if (!empty($user->mobile)) {
       $post['mobile'] = $user->mobile;
       $requiredSet = true;
     }
@@ -260,7 +260,7 @@ class MB_Toolbox
     }
 
     // Optional fields that require formatting
-    if (isset($user->birthdate) && strpos($user->birthdate, '/') > 0 && strtotime($user->birthdate) != FALSE) {
+    if (isset($user->birthdate) && strtotime($user->birthdate)) {
       $post['birthdate'] = date('Y-m-d', strtotime($user->birthdate));
     }
     elseif (isset($user->birthdate) && is_int($user->birthdate)) {
@@ -273,15 +273,15 @@ class MB_Toolbox
     $northstarUrl =  $northstarAPIConfig['host'];
     $port = $northstarAPIConfig['port'];
     if ($port > 0 && is_numeric($port)) {
-      $northstarUrl .= ":{$port}";
+      $northstarUrl .= ':' . $port;
     }
-    $northstarUrl .= self::NORTHSTAR . '/users';
+    $northstarUrl .= '/' . self::NORTHSTAR_API_VERSION . '/users';
     $result = $this->mbToolboxcURL->curlPOST($northstarUrl, $post);
 
-    if ($result[1] == 201) {
+    if ($result[1] === 201) {
       echo '- Northstar user created.', PHP_EOL;
     }
-    elseif ($result[1] == 200) {
+    elseif ($result[1] === 200) {
       echo '- Northstar user updated.', PHP_EOL;
     }
     else {

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -13,6 +13,7 @@ class MB_Toolbox
 {
 
   const DRUPAL_API = '/api/v1';
+  const NORTHSTAR = '/v1';
   const DEFAULT_USERNAME = 'Doer';
 
   /**
@@ -173,7 +174,6 @@ class MB_Toolbox
         $post['country'] = $user->country;
       }
 
-      $ch = curl_init();
       $dsDrupalAPIConfig = $this->mbConfig->getProperty('ds_drupal_api_config');
       $drupalAPIUrl =  $dsDrupalAPIConfig['host'];
       $port = $dsDrupalAPIConfig['port'];
@@ -198,6 +198,24 @@ class MB_Toolbox
     }
 
     return $result;
+  }
+
+  /**
+   *
+   */
+  public function createNorthstarUser($user) {
+
+    $post = [];
+
+    $northstarAPIConfig = $this->mbConfig->getProperty('ds_drupal_api_config');
+    $northstarUrl =  $northstarAPIConfig['host'];
+    $port = $northstarAPIConfig['port'];
+    if ($port > 0 && is_numeric($port)) {
+      $northstarUrl .= ":{$port}";
+    }
+    $northstarUrl .= self::NORTHSTAR . '/register';
+    $result = $this->mbToolboxcURL->curlPOST($northstarUrl, $post);
+
   }
 
   /**

--- a/src/MB_Toolbox_BaseProducer.php
+++ b/src/MB_Toolbox_BaseProducer.php
@@ -30,7 +30,7 @@ abstract class MB_Toolbox_BaseProducer
   protected $statHat;
 
   /**
-   * startTime - The date the request message started to be generated. Note that the extending class
+   * The date the request message started to be generated. Note that the extending class
    * can set this value based on the final generatePayload() call.
    *
    * @var string $startTime

--- a/src/MB_Toolbox_BaseProducer.php
+++ b/src/MB_Toolbox_BaseProducer.php
@@ -30,7 +30,8 @@ abstract class MB_Toolbox_BaseProducer
   protected $statHat;
 
   /**
-   * startTime - The date the request message started to be generated.
+   * startTime - The date the request message started to be generated. Note that the extending class
+   * can set this value based on the final generatePayload() call.
    *
    * @var string $startTime
    */

--- a/src/MB_Toolbox_cURL.php
+++ b/src/MB_Toolbox_cURL.php
@@ -200,7 +200,8 @@ class MB_Toolbox_cURL
         )
       );
     }
-    elseif (strpos($curlUrl, 'api.dosomething') !== FALSE && isset($northstarConfig['id']) && isset($northstarConfig['key'])) {
+    elseif (isset($northstarConfig['host']) && strpos($curlUrl, $northstarConfig['host']) !== FALSE &&
+            isset($northstarConfig['id']) && isset($northstarConfig['key'])) {
       curl_setopt($ch, CURLOPT_HTTPHEADER,
         array(
           'Content-type: application/json',

--- a/src/MB_Toolbox_cURL.php
+++ b/src/MB_Toolbox_cURL.php
@@ -200,8 +200,7 @@ class MB_Toolbox_cURL
         )
       );
     }
-    elseif (isset($northstarConfig['host']) && strpos($curlUrl, $northstarConfig['host']) !== FALSE &&
-            isset($northstarConfig['id']) && isset($northstarConfig['key'])) {
+    elseif (isNorthstar($northstarConfig, $curlUrl)) {
       curl_setopt($ch, CURLOPT_HTTPHEADER,
         array(
           'Content-type: application/json',
@@ -362,6 +361,26 @@ class MB_Toolbox_cURL
     else {
       throw new Exception('buildcURL required host setting missing.');
     }
+  }
+
+  /**
+   * Test if the Northstar configuration settings are valid and the cURL is for Northstar.
+   *
+   * @param array $northstarConfig
+   *   Configuration settings for connecting to Northstar API
+   * @param string $curlUrl
+   *   A cURL path.
+   */
+  private function isNorthstar($northstarConfig, $curlUrl) {
+
+    if (!empty($northstarConfig['host']) &&
+        strpos($curlUrl, $northstarConfig['host']) !== FALSE &&
+        !empty($northstarConfig['id']) &&
+        !empty($northstarConfig['key'])) {
+          return true;
+    }
+
+    return false;
   }
 
 }

--- a/src/MB_Toolbox_cURL.php
+++ b/src/MB_Toolbox_cURL.php
@@ -373,14 +373,23 @@ class MB_Toolbox_cURL
    */
   private function isNorthstar($northstarConfig, $curlUrl) {
 
-    if (!empty($northstarConfig['host']) &&
-        strpos($curlUrl, $northstarConfig['host']) !== FALSE &&
-        !empty($northstarConfig['id']) &&
-        !empty($northstarConfig['key'])) {
-          return true;
+    // Confirm each of the required config settings are available
+    if (empty($northstarConfig['host'])) {
+      return false;
+    }
+    if (empty($northstarConfig['id'])) {
+      return false;
+    }
+    if (empty($northstarConfig['key'])) {
+      return false;
     }
 
-    return false;
+    // Validate cURL as being for Northstar
+    if (!strpos($curlUrl, $northstarConfig['host'])) {
+      return false;
+    }
+
+    return true;
   }
 
 }


### PR DESCRIPTION
Fixes #61 

Moving `mbc-user-import` user data storage to Northstar from Phoenix. Add method to call Northstar.

- Add `createNorthstarUser()` method to support creating users based on https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user

**Related**:
- https://github.com/DoSomething/mbc-user-import/issues/63