### PR TITLE
Fix logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dosomething/mb-toolbox",
     "type": "library",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "A library of functionality shared between the components that make up the Quicksilver system: https://github.com/DoSomething/message-broker. Some of the functionality is DoSomething.org specific.",
     "keywords": ["rabbitmq", "message broker", "quicksilver", "php", "library"],
     "homepage": "https://github.com/DoSomething/mb-toolbox",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mb-toolbox",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Task runner for messagebroker-phplib library to run validation and code linting.",
   "engines": {
     "node": ">=4.4.x"

--- a/src/MB_Toolbox.php
+++ b/src/MB_Toolbox.php
@@ -323,9 +323,9 @@ class MB_Toolbox
       $result = $this->mbToolboxcURL->curlGet($endpoint);
 
       try {
+        $northstarUser = $this->parseNorthstarUserResponse($result);
         echo '- User loaded from Northstar by email: '
           . $user->email . PHP_EOL;
-        $northstarUser = $this->parseNorthstarUserResponse($result);
         return $northstarUser;
       } catch (Exception $e) {
         echo '- Coundn\'t load user from Northstar by email: '
@@ -335,13 +335,13 @@ class MB_Toolbox
 
     // Lookup by phone.
     if (!empty($user->mobile)) {
-      echo '- User loaded from Northstar by mobile: '
-        . $user->mobile . PHP_EOL;
       $endpoint = $northstarUrl . 'users/mobile/' . $user->mobile;
       $result = $this->mbToolboxcURL->curlGet($endpoint);
 
       try {
         $northstarUser = $this->parseNorthstarUserResponse($result);
+        echo '- User loaded from Northstar by mobile: '
+          . $user->mobile . PHP_EOL;
         return $northstarUser;
       } catch (Exception $e) {
         echo '- Coundn\'t load user from Northstar by mobile: '


### PR DESCRIPTION
Fixes incorrect logging. Example:

```
- User loaded from Northstar by email: ***@gmail.com
- Coundn't load user from Northstar by email: ***@gmail.com
- User loaded from Northstar by mobile: (555)555-0672
- Coundn't load user from Northstar by mobile: (555)555-0672
- Northstar user created.
```

"User loaded from Northstar by email" and  "... by mobile" should have been logged after `parseNorthstarUserResponse()` in `try` statement.