### PR TITLE
Fix AMQPMessage class namespace

### DIFF
--- a/src/MB_Toolbox_BaseConsumer.php
+++ b/src/MB_Toolbox_BaseConsumer.php
@@ -6,9 +6,11 @@
 
 namespace DoSomething\MB_Toolbox;
 
+use \Exception;
+use PhpAmqpLib\Message\AMQPMessage;
+
 use DoSomething\MB_Toolbox\MB_Configuration;
 use DoSomething\StatHat\Client as StatHat;
-use \Exception;
 
 /**
  * Class MB_Toolbox_BaseConsumer


### PR DESCRIPTION
Forgot to include namespace for `AMQPMessage` class.